### PR TITLE
Input Race Condition Fix

### DIFF
--- a/ci/base.html
+++ b/ci/base.html
@@ -387,7 +387,11 @@
       }
 
       function handleDiffSetInnerHTML(message, el) {
-        const { content } = message;
+        let { content } = message;
+
+        if (content === undefined) {
+          content = "";
+        }
 
         if (el.nodeType === Node.TEXT_NODE) {
           el.textContent = content;

--- a/component.go
+++ b/component.go
@@ -233,6 +233,10 @@ func (l *LiveComponent) Update() {
 	l.notifyStage(Updated)
 }
 
+func (l *LiveComponent) UpdateWithSource(source *EventSource) {
+	l.notifyStageWithSource(Updated, source)
+}
+
 // Kill ...
 func (l *LiveComponent) Kill() error {
 
@@ -369,6 +373,10 @@ func (l *LiveComponent) getChildrenComponents() []*LiveComponent {
 }
 
 func (l *LiveComponent) notifyStage(ltu LifeTimeStage) {
+	l.notifyStageWithSource(ltu, nil)
+}
+
+func (l *LiveComponent) notifyStageWithSource(ltu LifeTimeStage, source *EventSource) {
 	if l.life == nil {
 		l.log(LogWarn, "component life updates channel is nil", nil)
 		return
@@ -377,6 +385,7 @@ func (l *LiveComponent) notifyStage(ltu LifeTimeStage) {
 	*l.life <- ComponentLifeTimeMessage{
 		Stage:     ltu,
 		Component: l,
+		Source:    source,
 	}
 }
 

--- a/component_lifetime.go
+++ b/component_lifetime.go
@@ -23,6 +23,18 @@ const (
 type ComponentLifeTimeMessage struct {
 	Stage     LifeTimeStage
 	Component *LiveComponent
+	Source    *EventSource
 }
 
 type ComponentLifeCycle chan ComponentLifeTimeMessage
+
+type EventSource struct {
+	Type  EventSourceType
+	Value string
+}
+
+type EventSourceType string
+
+const (
+	EventSourceInput = "input"
+)

--- a/html_page.go
+++ b/html_page.go
@@ -389,7 +389,11 @@ var BasePageString = `<!DOCTYPE html>
       }
 
       function handleDiffSetInnerHTML(message, el) {
-        const { content } = message;
+        let { content } = message;
+
+        if (content === undefined) {
+          content = "";
+        }
 
         if (el.nodeType === Node.TEXT_NODE) {
           el.textContent = content;

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package golive
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -140,6 +141,13 @@ func (s *LiveServer) CreateHTMLHandlerWithMiddleware(f func(ctx context.Context)
 }
 
 func (s *LiveServer) HandleWSRequest(c *websocket.Conn) {
+	defer func() {
+		payload := recover()
+		if payload != nil {
+			s.Log(LogWarn, fmt.Sprintf("ws request panic recovered: %v", payload), nil)
+		}
+	}()
+
 	c.EnableWriteCompression(true)
 
 	sessionKey := c.Cookies(s.CookieName)


### PR DESCRIPTION
- Track the source of an event when triggered by a LiveInput, in that case prevent updated to input's value
- SetInnerHTML set's content to undefined when no content set