### PR TITLE
Session Status

### DIFF
--- a/server.go
+++ b/server.go
@@ -156,7 +156,7 @@ func (s *LiveServer) HandleWSRequest(c *websocket.Conn) {
 
 	session := s.Wire.GetSession(sessionKey)
 
-	if session == nil {
+	if session == nil || session.Status != SessionNew {
 		s.Log(LogWarn, "session not found", logEx{"session": sessionKey})
 
 		var msg PatchBrowser
@@ -175,6 +175,7 @@ func (s *LiveServer) HandleWSRequest(c *websocket.Conn) {
 		return
 	}
 
+	session.Status = SessionOpen
 	exit := make(chan int)
 	exited := false
 
@@ -189,6 +190,8 @@ func (s *LiveServer) HandleWSRequest(c *websocket.Conn) {
 				}
 			case <-exit:
 				exited = true
+
+				session.Status = SessionClosed
 
 				if err := c.Close(); err != nil {
 					s.Log(LogError, "close websocket connection", logEx{"error": err})

--- a/session.go
+++ b/session.go
@@ -38,15 +38,25 @@ type DOMEvent struct {
 	KeyCode string `json:"keyCode"`
 }
 
+type SessionStatus string
+
+const (
+	SessionNew    SessionStatus = "n"
+	SessionOpen   SessionStatus = "o"
+	SessionClosed SessionStatus = "c"
+)
+
 type Session struct {
 	LivePage   *Page
 	OutChannel chan PatchBrowser
 	log        Log
+	Status     SessionStatus
 }
 
 func NewSession() *Session {
 	return &Session{
 		OutChannel: make(chan PatchBrowser),
+		Status:     SessionNew,
 	}
 }
 


### PR DESCRIPTION
A session can have a new, open, or closed status.

Using session status to prevent reuse of a session.

I was able to trigger this state by doing the following.

- Load a page in a tab (Tab A)
- Load same page in a new tab of the same browser (Tab B)
- In Tab A browser to an off-site page
- In Tab A use the browser's back button
- Tab A now have reused Tab B's session

These statuses could also later be used to:
- track the number of open connections on a single server
- allow a session to be reconnected
- allow a session to be a move to a cache or database so connect/reconnect can happen on another server