### PR TITLE
fix: event source component was always EntryComponent

### DIFF
--- a/live/page.go
+++ b/live/page.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"github.com/brendonmatos/golive/differ"
 	"html/template"
 	"reflect"
+
+	"github.com/brendonmatos/golive/differ"
 )
 
 var BasePage *template.Template
@@ -144,7 +145,7 @@ func (lp *Page) EmitWithSource(lts int, c *Component, source *EventSource) {
 
 	lp.Events <- LivePageEvent{
 		Type:      lts,
-		Component: lp.EntryComponent,
+		Component: c,
 		Source:    source,
 	}
 }


### PR DESCRIPTION
I was getting weird behavior sometime, only 1 component was reactive in the whole page. After a little a digging I find that the `lce` event was sending the same component id
![image](https://user-images.githubusercontent.com/1301995/126084924-3201a4d2-987d-4bc0-9d9c-788df28b9f42.png)
